### PR TITLE
Initial refactor to not make user supply key

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -4,3 +4,4 @@
 ^README\.Rmd$
 ^img$
 ^\.github$
+^data$

--- a/R/get_rts_data.R
+++ b/R/get_rts_data.R
@@ -5,10 +5,23 @@
 #' @return A data frame with the raw data
 #' @export
 
-get_rts_data <- function(redcap_api_token) {
+get_rts_data <- function(redcap_api_token = get_token()) {
   redcap_read(
     redcap_uri = "https://redcap.uoregon.edu/api/",
     token = redcap_api_token,
     format = "json"
   )$data
+}
+
+get_token <- function() {
+  key <- Sys.getenv("redcap_rts_token")
+  if(nchar(key) < 1) {
+    return(stop(paste0(
+      "Key not found in R Environment. Please inspect ",
+      "`usethis::edit_r_environ()` and ensure your api token is called ",
+      "'redcap_rts_token' or provide the key to the function directly."
+    ), call. = FALSE
+    ))
+  }
+  key
 }

--- a/README.Rmd
+++ b/README.Rmd
@@ -38,7 +38,7 @@ After you've completed this, you can download the raw data with the following co
 
 ```{r example, message = FALSE}
 library(rts)
-d <- get_rts_data(Sys.getenv("redcap_rts_token"))
+d <- get_rts_data()
 
 nrow(d)
 ncol(d)

--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ following code.
 
 ``` r
 library(rts)
-d <- get_rts_data(Sys.getenv("redcap_rts_token"))
+d <- get_rts_data()
 
 nrow(d)
-#> [1] 85
+#> [1] 99
 ncol(d)
 #> [1] 5490
 ```

--- a/man/get_rts_data.Rd
+++ b/man/get_rts_data.Rd
@@ -4,7 +4,7 @@
 \alias{get_rts_data}
 \title{Return full REDCap data}
 \usage{
-get_rts_data(redcap_api_token)
+get_rts_data(redcap_api_token = get_token())
 }
 \arguments{
 \item{redcap_api_token}{The API token from REDCap, passed as a string}


### PR DESCRIPTION
This makes it so you don't have to supply the key. It will grab it from your `.Renviron` if it's there. If not, it will give an error.

Still needs some work. Running into some R CMD Check warnings on my local.